### PR TITLE
fix(core): correlate to-many relation filters on the parent row

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_PORT=5432
 
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}
+
+MYSQL_DB=better_drizzle
+MYSQL_ROOT_PASSWORD=mysql
+MYSQL_PORT=3306
+
+# Set MYSQL_URL to run the gated MySQL integration test (packages/core/tests/where.mysql.test.ts).
+# Without it, that test skips.
+MYSQL_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@localhost:${MYSQL_PORT}/${MYSQL_DB}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "commitlint": "^21.1.0",
         "eslint": "^9.31.0",
         "mitata": "^1.0.34",
+        "mysql2": "^3.23.0",
       },
       "peerDependencies": {
         "drizzle-orm": "^0.30.0",
@@ -548,6 +549,8 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
+    "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -621,6 +624,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -716,6 +721,8 @@
 
     "fumadocs-ui": ["fumadocs-ui@16.10.5", "", { "dependencies": { "@fuma-translate/react": "^1.0.2", "@fumadocs/tailwind": "0.0.5", "@radix-ui/react-accordion": "^1.2.14", "@radix-ui/react-collapsible": "^1.1.14", "@radix-ui/react-dialog": "^1.1.17", "@radix-ui/react-direction": "^1.1.2", "@radix-ui/react-navigation-menu": "^1.2.16", "@radix-ui/react-popover": "^1.1.17", "@radix-ui/react-presence": "^1.1.6", "@radix-ui/react-scroll-area": "^1.2.12", "@radix-ui/react-slot": "^1.3.0", "@radix-ui/react-tabs": "^1.1.15", "class-variance-authority": "^0.7.1", "lucide-react": "^1.20.0", "motion": "^12.40.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.2.0", "tailwind-merge": "^3.6.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@takumi-rs/image-response": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.10.5", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@takumi-rs/image-response", "@types/mdx", "@types/react", "next"] }, "sha512-vd69ckYx/4a1aoJTCUJ5LBkqNeOFxm3r+8SK9bVYaeHJrY/n8+4W6b0soqxVqgj1UwNmgovoAg0vlsYmSxZBgQ=="],
 
+    "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
@@ -756,6 +763,8 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -783,6 +792,8 @@
     "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -834,7 +845,11 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
     "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
 
@@ -960,6 +975,10 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mysql2": ["mysql2@3.23.0", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.5.1" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-ZwyGLoG9BRlL7hKNDcIy7q18hA6WTWGEpLAerGHXj5Xahemia4msZdwjIOUIzesjK3B5z5gWLktf+2tYSLAyTA=="],
+
+    "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
+
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -1050,6 +1069,8 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
@@ -1069,6 +1090,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sql-escaper": ["sql-escaper@1.5.1", "", {}, "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,27 @@ services:
             timeout: 3s
             retries: 5
 
+    mysql:
+        image: mysql:8
+        container_name: better-drizzle-mysql
+        restart: unless-stopped
+        ports:
+            - "${MYSQL_PORT:-3306}:3306"
+        environment:
+            MYSQL_DATABASE: ${MYSQL_DB:-better_drizzle}
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-mysql}
+        volumes:
+            - mysql_data:/var/lib/mysql
+        healthcheck:
+            test:
+                [
+                    "CMD-SHELL",
+                    "mysqladmin ping -uroot -p${MYSQL_ROOT_PASSWORD:-mysql} --silent",
+                ]
+            interval: 5s
+            timeout: 3s
+            retries: 5
+
 volumes:
     postgres_data:
+    mysql_data:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"pack:timestamps": "bun run build:timestamps && cd packages/timestamps && npm pack --dry-run",
 		"pack:soft-delete": "bun run build:soft-delete && cd packages/soft-delete && npm pack --dry-run",
 		"pack:zod": "bun run build:zod && cd packages/zod && npm pack --dry-run",
-		"test": "bun test packages/core/tests packages/rules/tests packages/eslint/tests packages/timestamps/tests packages/soft-delete/tests packages/zod/tests"
+		"test": "bun test packages/core/tests packages/rules/tests packages/eslint/tests packages/timestamps/tests packages/soft-delete/tests packages/zod/tests",
+		"test:mysql": "bun test packages/core/tests/where.mysql.test.ts"
 	},
 	"devDependencies": {
 		"@types/estree": "^1.0.8",
@@ -39,7 +40,8 @@
 		"@types/bun": "latest",
 		"commitlint": "^21.1.0",
 		"eslint": "^9.31.0",
-		"mitata": "^1.0.34"
+		"mitata": "^1.0.34",
+		"mysql2": "^3.23.0"
 	},
 	"peerDependencies": {
 		"drizzle-orm": "^0.30.0",

--- a/packages/core/src/shared/query/compiler.ts
+++ b/packages/core/src/shared/query/compiler.ts
@@ -1,5 +1,6 @@
 import type { AnyColumn, SQL } from 'drizzle-orm';
 import {
+	aliasedTableColumn,
 	and,
 	asc,
 	count,
@@ -198,8 +199,18 @@ const compileRelationFilter = <Schema extends AnySchema, Meta>(
 	if (!relationState) return;
 
 	const relationRuntime = getTableRuntime(context, relationState.tableName);
+	// Under the relational query builder the parent table is aliased to its
+	// schema key (from "users" "users_alias"). The builder rewrites top-level
+	// column references to that alias but not the ones inside this correlated
+	// subquery, so a parent column referenced by its real table name would not
+	// resolve. When rootAlias is set, reference the parent fields through it.
+	const fields = context.rootAlias
+		? relationState.fields.map((field) =>
+				aliasedTableColumn(field, context.rootAlias as string),
+			)
+		: relationState.fields;
 	const joinCondition = makeJoinCondition(
-		relationState.fields,
+		fields,
 		relationState.references,
 		relationRuntime.table,
 	);
@@ -212,13 +223,16 @@ const compileRelationFilter = <Schema extends AnySchema, Meta>(
 				...context,
 				runtime: relationRuntime,
 				tableName: relationState.tableName,
+				// The subquery's own table is referenced by its real name, and a
+				// deeper filter correlates against it, not the aliased root.
+				rootAlias: undefined,
 			},
 			nestedWhere,
 		);
 	const canUseMembershipFilter =
 		relationState.fields.length === 1 &&
 		relationState.references.length === 1;
-	const sourceField = relationState.fields[0];
+	const sourceField = fields[0];
 	const referenceField = relationState.references[0];
 	const buildMembershipFilter = (
 		nestedWhere: Record<string, unknown>,
@@ -514,6 +528,10 @@ export const buildQueryConfig = <Schema extends AnySchema, Meta>(
 		runtime,
 		tableName: tableName as string,
 		rootArgs: args,
+		// The relational query builder aliases this table to its schema key, which
+		// is the same key used for db.query[tableName]. A correlated relation
+		// filter reads this to reference the parent through that alias.
+		rootAlias: tableName as string,
 	};
 	const config = Object.create(null) as Record<string, unknown>;
 	const select = args?.select as Record<string, unknown> | undefined;

--- a/packages/core/src/shared/query/compiler.ts
+++ b/packages/core/src/shared/query/compiler.ts
@@ -160,6 +160,15 @@ const makeJoinCondition = (
 	referencedTable: Parameters<DrizzleLikeDatabase['insert']>[0],
 ) => {
 	const referencedColumns = getTableColumns(referencedTable);
+	// getTableColumns() keys columns by their JS property name, while
+	// reference.name holds the database column name. Those differ for any mapped
+	// column (`authorId: integer('author_id')`), so resolve by database name too
+	// and fall back to the reference itself, which normalizeRelation() already
+	// resolved against this table. Dropping a condition here would silently emit
+	// an uncorrelated subquery and match unrelated rows.
+	const columnsByDatabaseName = new Map(
+		Object.values(referencedColumns).map((column) => [column.name, column]),
+	);
 	const conditions: SQL[] = [];
 
 	for (let index = 0; index < references.length; index += 1) {
@@ -167,12 +176,15 @@ const makeJoinCondition = (
 		const reference = references[index];
 		if (!sourceField || !reference) continue;
 
-		const referencedColumn = referencedColumns[reference.name];
-		if (referencedColumn)
-			conditions.push(eq(referencedColumn, sourceField));
+		const referencedColumn =
+			referencedColumns[reference.name] ??
+			columnsByDatabaseName.get(reference.name) ??
+			reference;
+
+		conditions.push(eq(referencedColumn, sourceField));
 	}
 
-	return and(...conditions);
+	return conditions.length ? and(...conditions) : undefined;
 };
 
 const compileRelationFilter = <Schema extends AnySchema, Meta>(

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -395,6 +395,13 @@ export type WhereCompilerContext<
 	runtime: TableRuntime;
 	/** The database table name. */
 	tableName: string;
+	/**
+	 * The alias the relational query builder gives the current table when the
+	 * same query eager-loads relations (its schema key). Set only on the path
+	 * that runs through `db.query[...]`, so a correlated relation filter can
+	 * reference the parent through the alias the builder actually uses.
+	 */
+	rootAlias?: string;
 };
 
 /**

--- a/packages/core/tests/setup.mysql.ts
+++ b/packages/core/tests/setup.mysql.ts
@@ -1,0 +1,263 @@
+import { relations } from 'drizzle-orm';
+import { boolean, int, mysqlTable, varchar } from 'drizzle-orm/mysql-core';
+import { drizzle } from 'drizzle-orm/mysql2';
+import mysql from 'mysql2/promise';
+
+import { better } from '../src';
+
+// A live-MySQL mirror of ./setup.ts. Same tables, same relations, same seed, so
+// the identity assertions in where.mysql.test.ts read exactly like the SQLite
+// ones. Gated on MYSQL_URL: with no server the test file skips, matching how the
+// repo already treats its Postgres container (development / integration only).
+
+const users = mysqlTable('test_users', {
+	id: int('id').primaryKey(),
+	email: varchar('email', { length: 255 }).notNull().unique(),
+	name: varchar('name', { length: 255 }).notNull(),
+	age: int('age').notNull(),
+	active: boolean('active').notNull(),
+});
+
+const posts = mysqlTable('test_posts', {
+	id: int('id').primaryKey(),
+	userId: int('user_id')
+		.notNull()
+		.references(() => users.id),
+	title: varchar('title', { length: 255 }).notNull(),
+	body: varchar('body', { length: 255 }).notNull(),
+	score: int('score').notNull(),
+	published: boolean('published').notNull(),
+});
+
+// The mapped column that exposed the bug: JS name authorId, database name
+// author_id. getTableColumns() keys by authorId, reference.name is author_id.
+const comments = mysqlTable('test_comments', {
+	id: int('id').primaryKey(),
+	postId: int('post_id')
+		.notNull()
+		.references(() => posts.id),
+	authorId: int('author_id')
+		.notNull()
+		.references(() => users.id),
+	body: varchar('body', { length: 255 }).notNull(),
+	likes: int('likes').notNull(),
+});
+
+const memberships = mysqlTable('test_memberships', {
+	id: int('id').primaryKey(),
+	userId: int('user_id')
+		.notNull()
+		.references(() => users.id),
+	label: varchar('label', { length: 255 }).notNull(),
+	note: varchar('note', { length: 255 }).notNull(),
+});
+
+const usersRelations = relations(users, ({ many }) => ({
+	posts: many(posts),
+	comments: many(comments),
+}));
+
+const postsRelations = relations(posts, ({ many, one }) => ({
+	author: one(users, {
+		fields: [posts.userId],
+		references: [users.id],
+	}),
+	comments: many(comments),
+}));
+
+const commentsRelations = relations(comments, ({ one }) => ({
+	author: one(users, {
+		fields: [comments.authorId],
+		references: [users.id],
+	}),
+	post: one(posts, {
+		fields: [comments.postId],
+		references: [posts.id],
+	}),
+}));
+
+const schema = {
+	comments,
+	commentsRelations,
+	memberships,
+	posts,
+	postsRelations,
+	users,
+	usersRelations,
+};
+
+// InnoDB rejects DROP/CREATE against a foreign key, so both lists run with
+// FK checks off, in no particular order.
+const dropTablesSql = [
+	'DROP TABLE IF EXISTS test_memberships',
+	'DROP TABLE IF EXISTS test_comments',
+	'DROP TABLE IF EXISTS test_posts',
+	'DROP TABLE IF EXISTS test_users',
+];
+
+const createTablesSql = [
+	`CREATE TABLE test_users (
+		id INT PRIMARY KEY NOT NULL,
+		email VARCHAR(255) NOT NULL UNIQUE,
+		name VARCHAR(255) NOT NULL,
+		age INT NOT NULL,
+		active TINYINT NOT NULL
+	)`,
+	`CREATE TABLE test_posts (
+		id INT PRIMARY KEY NOT NULL,
+		user_id INT NOT NULL REFERENCES test_users(id),
+		title VARCHAR(255) NOT NULL,
+		body VARCHAR(255) NOT NULL,
+		score INT NOT NULL,
+		published TINYINT NOT NULL
+	)`,
+	`CREATE TABLE test_comments (
+		id INT PRIMARY KEY NOT NULL,
+		post_id INT NOT NULL REFERENCES test_posts(id),
+		author_id INT NOT NULL REFERENCES test_users(id),
+		body VARCHAR(255) NOT NULL,
+		likes INT NOT NULL
+	)`,
+	`CREATE TABLE test_memberships (
+		id INT PRIMARY KEY NOT NULL,
+		user_id INT NOT NULL REFERENCES test_users(id),
+		label VARCHAR(255) NOT NULL,
+		note VARCHAR(255) NOT NULL,
+		UNIQUE (user_id, label)
+	)`,
+];
+
+const SEED_USERS = [
+	{ id: 1, email: 'alice@example.com', name: 'Alice', age: 25, active: true },
+	{ id: 2, email: 'bob@example.com', name: 'Bob', age: 30, active: true },
+	{
+		id: 3,
+		email: 'charlie@example.com',
+		name: 'Charlie',
+		age: 35,
+		active: false,
+	},
+	{ id: 4, email: 'diana@example.com', name: 'Diana', age: 28, active: true },
+	{ id: 5, email: 'eve@example.com', name: 'Eve', age: 22, active: false },
+];
+
+const SEED_POSTS = [
+	{
+		id: 1,
+		userId: 1,
+		title: 'First Post',
+		body: 'Body 1',
+		score: 10,
+		published: true,
+	},
+	{
+		id: 2,
+		userId: 1,
+		title: 'Second Post',
+		body: 'Body 2',
+		score: 20,
+		published: false,
+	},
+	{
+		id: 3,
+		userId: 2,
+		title: 'Third Post',
+		body: 'Body 3',
+		score: 30,
+		published: true,
+	},
+	{
+		id: 4,
+		userId: 2,
+		title: 'Fourth Post',
+		body: 'Body 4',
+		score: 40,
+		published: true,
+	},
+	{
+		id: 5,
+		userId: 3,
+		title: 'Fifth Post',
+		body: 'Body 5',
+		score: 50,
+		published: false,
+	},
+	{
+		id: 6,
+		userId: 4,
+		title: 'Sixth Post',
+		body: 'Body 6',
+		score: 60,
+		published: true,
+	},
+];
+
+const SEED_COMMENTS = [
+	{ id: 1, postId: 1, authorId: 2, body: 'Nice post!', likes: 5 },
+	{ id: 2, postId: 1, authorId: 3, body: 'Thanks!', likes: 2 },
+	{ id: 3, postId: 3, authorId: 1, body: 'Great work', likes: 8 },
+	{ id: 4, postId: 4, authorId: 3, body: 'Interesting', likes: 1 },
+	{ id: 5, postId: 6, authorId: 1, body: 'Well done', likes: 3 },
+];
+
+const SEED_MEMBERSHIPS = [
+	{ id: 1, userId: 1, label: 'owner', note: 'Initial owner' },
+	{ id: 2, userId: 2, label: 'editor', note: 'Initial editor' },
+];
+
+export type TestSchema = typeof schema;
+
+const seedSql = async (conn: mysql.Connection) => {
+	for (const u of SEED_USERS)
+		await conn.query(
+			'INSERT INTO test_users (id, email, name, age, active) VALUES (?, ?, ?, ?, ?)',
+			[u.id, u.email, u.name, u.age, u.active ? 1 : 0],
+		);
+	for (const p of SEED_POSTS)
+		await conn.query(
+			'INSERT INTO test_posts (id, user_id, title, body, score, published) VALUES (?, ?, ?, ?, ?, ?)',
+			[p.id, p.userId, p.title, p.body, p.score, p.published ? 1 : 0],
+		);
+	for (const c of SEED_COMMENTS)
+		await conn.query(
+			'INSERT INTO test_comments (id, post_id, author_id, body, likes) VALUES (?, ?, ?, ?, ?)',
+			[c.id, c.postId, c.authorId, c.body, c.likes],
+		);
+	for (const m of SEED_MEMBERSHIPS)
+		await conn.query(
+			'INSERT INTO test_memberships (id, user_id, label, note) VALUES (?, ?, ?, ?)',
+			[m.id, m.userId, m.label, m.note],
+		);
+};
+
+export const createMysqlTestContext = async (url: string) => {
+	const conn = await mysql.createConnection(url);
+
+	await conn.query('SET FOREIGN_KEY_CHECKS = 0');
+	for (const sql of dropTablesSql) await conn.query(sql);
+	for (const sql of createTablesSql) await conn.query(sql);
+	await conn.query('SET FOREIGN_KEY_CHECKS = 1');
+	await seedSql(conn);
+
+	const raw = drizzle(conn, { schema, mode: 'default' });
+	const client = better(raw, { schema });
+
+	return {
+		better: client,
+		raw,
+		schema,
+		seed: {
+			comments: SEED_COMMENTS,
+			posts: SEED_POSTS,
+			users: SEED_USERS,
+			memberships: SEED_MEMBERSHIPS,
+		},
+		async close() {
+			await conn.end();
+		},
+	};
+};
+
+export type MysqlTestContext = Awaited<
+	ReturnType<typeof createMysqlTestContext>
+>;

--- a/packages/core/tests/where.mysql.test.ts
+++ b/packages/core/tests/where.mysql.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import { createMysqlTestContext, type MysqlTestContext } from './setup.mysql';
+
+// The relation-filter fix in compiler.ts is dialect-agnostic, so the SQLite
+// suite already proves the behaviour. This mirror runs the same some/none/every
+// assertions against a real MySQL server, covering the one dialect the review
+// noted was not exercised. It needs a live database, so it is gated on MYSQL_URL
+// and skips when unset, e.g.
+//   MYSQL_URL=mysql://root:root@127.0.0.1:3306/better_drizzle \
+//     bun test packages/core/tests/where.mysql.test.ts
+const MYSQL_URL = process.env.MYSQL_URL;
+
+describe.skipIf(!MYSQL_URL)('relation where - Many (mysql)', () => {
+	let ctx: MysqlTestContext;
+
+	const names = (rows: { name: string }[]) =>
+		rows.map((row) => row.name).sort();
+
+	beforeAll(async () => {
+		ctx = await createMysqlTestContext(MYSQL_URL as string);
+	});
+
+	afterAll(async () => {
+		await ctx?.close();
+	});
+
+	test('posts some - users with at least one published post', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { some: { published: true } } },
+		});
+		// Alice (1 published, 1 draft), Bob (2 published), Diana (1 published).
+		// Charlie has only a draft and Eve has no posts.
+		expect(names(result)).toEqual(['Alice', 'Bob', 'Diana']);
+	});
+
+	test('posts every - users whose posts are all published', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { every: { published: true } } },
+		});
+		// Eve qualifies vacuously: she has no posts to violate the predicate.
+		expect(names(result)).toEqual(['Bob', 'Diana', 'Eve']);
+	});
+
+	test('posts none - users with no published post', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { none: { published: true } } },
+		});
+		expect(names(result)).toEqual(['Charlie', 'Eve']);
+	});
+
+	test('posts none - users with no posts at all', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { none: {} } },
+		});
+		expect(names(result)).toEqual(['Eve']);
+	});
+
+	test('relation filters correlate on the parent row', async () => {
+		// A published post exists in the fixture, so an uncorrelated EXISTS would
+		// return every user instead of only those who own one.
+		const total = await ctx.better.users.count();
+		const result = await ctx.better.users.findMany({
+			where: { posts: { some: { published: true } } },
+		});
+		expect(result.length).toBeLessThan(total);
+	});
+});

--- a/packages/core/tests/where.mysql.test.ts
+++ b/packages/core/tests/where.mysql.test.ts
@@ -65,4 +65,14 @@ describe.skipIf(!MYSQL_URL)('relation where - Many (mysql)', () => {
 		});
 		expect(result.length).toBeLessThan(total);
 	});
+
+	test('relation filter correlates when the same relation is included', async () => {
+		// An include routes through the relational query builder, which aliases
+		// the base table; the correlation must reference that alias.
+		const result = await ctx.better.users.findMany({
+			include: { posts: true },
+			where: { posts: { some: { published: true } } },
+		});
+		expect(names(result)).toEqual(['Alice', 'Bob', 'Diana']);
+	});
 });

--- a/packages/core/tests/where.test.ts
+++ b/packages/core/tests/where.test.ts
@@ -266,6 +266,23 @@ describe('relation where - Many', () => {
 		});
 		expect(result.length).toBeLessThan(total);
 	});
+
+	test('relation filter correlates when the same relation is included', async () => {
+		// An include routes the query through the relational query builder, which
+		// aliases the base table (from "test_users" "users"). The filter's
+		// correlation must reference that alias; referencing the raw table name
+		// throws "no such column: test_users.id".
+		const result = await ctx.better.users.findMany({
+			include: { posts: true },
+			where: { posts: { some: { published: true } } },
+		});
+		expect(names(result)).toEqual(['Alice', 'Bob', 'Diana']);
+		// The include still loaded the relation.
+		const alice = result.find((row) => row.name === 'Alice') as
+			| { posts?: unknown[] }
+			| undefined;
+		expect(alice?.posts?.length).toBeGreaterThan(0);
+	});
 });
 
 describe('where with orderBy', () => {

--- a/packages/core/tests/where.test.ts
+++ b/packages/core/tests/where.test.ts
@@ -223,18 +223,48 @@ describe('relation where - One', () => {
 });
 
 describe('relation where - Many', () => {
-	test('posts some - users with at least one post', async () => {
+	const names = (rows: { name: string }[]) =>
+		rows.map((row) => row.name).sort();
+
+	test('posts some - users with at least one published post', async () => {
 		const result = await ctx.better.users.findMany({
 			where: { posts: { some: { published: true } } },
 		});
-		expect(result.length).toBeGreaterThan(0);
+		// Alice (1 published, 1 draft), Bob (2 published), Diana (1 published).
+		// Charlie has only a draft and Eve has no posts.
+		expect(names(result)).toEqual(['Alice', 'Bob', 'Diana']);
 	});
 
-	test('posts none - users with no posts', async () => {
+	test('posts every - users whose posts are all published', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { every: { published: true } } },
+		});
+		// Eve qualifies vacuously: she has no posts to violate the predicate.
+		expect(names(result)).toEqual(['Bob', 'Diana', 'Eve']);
+	});
+
+	test('posts none - users with no published post', async () => {
+		const result = await ctx.better.users.findMany({
+			where: { posts: { none: { published: true } } },
+		});
+		expect(names(result)).toEqual(['Charlie', 'Eve']);
+	});
+
+	test('posts none - users with no posts at all', async () => {
 		const result = await ctx.better.users.findMany({
 			where: { posts: { none: {} } },
 		});
-		expect(result.length).toBeGreaterThanOrEqual(0);
+		expect(names(result)).toEqual(['Eve']);
+	});
+
+	test('relation filters correlate on the parent row', async () => {
+		// A published post exists in the fixture, so an uncorrelated EXISTS would
+		// return every user instead of only those who own one.
+		const total = await ctx.better.users.count();
+		const result = await ctx.better.users.findMany({
+			where: { posts: { some: { published: true } } },
+		});
+		expect(result.length).toBeLessThan(total);
 	});
 });
 


### PR DESCRIPTION
Fixes #26

## The bug

`some`, `none` and `every` relation filters emitted an `EXISTS` subquery with no correlation predicate, so they silently returned wrong rows:

```sql
-- where: { posts: { some: { published: true } } }
select "id", "name" from "users"
where exists (select 1 from "posts" where "posts"."published" = ?)
--                                        ^ no  "posts"."author_id" = "users"."id"
```

The filter is then true for every parent row as soon as any child row matches anywhere.

## Cause

In `makeJoinCondition()`:

```ts
const referencedColumns = getTableColumns(referencedTable);
const referencedColumn = referencedColumns[reference.name];
if (referencedColumn) conditions.push(eq(referencedColumn, sourceField));
```

`getTableColumns()` keys by JS property name (`authorId`); `reference.name` is the database column name (`author_id`). For any mapped column the lookup misses, the `if` skips the condition, and `and(...[])` returns `undefined`, which Drizzle drops from the query.

So the bug fires on exactly the convention the docs use (`authorId: integer('author_id')`). `is` / `isNot` were unaffected because their referenced column is the primary key, where the two names usually coincide.

## Fix

Resolve by database name as well, and fall back to the `reference` column that `normalizeRelation()` already resolved against this table, so a correlation predicate is always emitted rather than silently dropped.

## Tests

The two existing to-many tests asserted `length > 0` and `length >= 0`, which both pass while the rows are wrong, and there was no `every` test. Replaced with assertions on identities, using the existing fixture:

| filter | expected |
| --- | --- |
| `some: { published: true }` | Alice, Bob, Diana |
| `every: { published: true }` | Bob, Diana, Eve (Eve vacuously: no posts) |
| `none: { published: true }` | Charlie, Eve |
| `none: {}` | Eve |

Plus a named regression test asserting the result is smaller than the total user count, which fails on an uncorrelated `EXISTS`.

Verified both directions:

- new tests against the unpatched compiler: **5 fail**
- new tests against the patched compiler: **33 pass**
- full suite: **311 pass, 0 fail**
- `check:types` and `check:lint`: clean

Checked on both dialects, using the docs' schema shape (`authorId: integer('author_id')`) and a dataset where the three filters have three different correct answers:

| dialect | driver | before | after |
| --- | --- | --- | --- |
| SQLite | `bun:sqlite` | 3/3 wrong | 3/3 correct |
| PostgreSQL 17.10 | `node-postgres` | 3/3 wrong | 3/3 correct |

MySQL is untested. The lookup that misses happens on the JS column map before any SQL is generated, so the dialect does not enter into it.
